### PR TITLE
Allow raw tls_options to be passed through to gen_smtp

### DIFF
--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -473,6 +473,10 @@ defmodule Bamboo.SMTPAdapter do
     [{:tls, value} | config]
   end
 
+  defp to_gen_smtp_server_config({:tls_options, value}, config) do
+    Keyword.put(config, :tls_options, value)
+  end
+
   defp to_gen_smtp_server_config({:allowed_tls_versions, value}, config) when is_binary(value) do
     Keyword.update(config, :tls_options, [{:versions, string_to_tls_versions(value)}], fn c ->
       [{:versions, string_to_tls_versions(value)} | c]

--- a/test/lib/bamboo/adapters/smtp_adapter_test.exs
+++ b/test/lib/bamboo/adapters/smtp_adapter_test.exs
@@ -774,6 +774,17 @@ defmodule Bamboo.SMTPAdapterTest do
     assert String.contains?(raw_email, rfc2231_filename)
   end
 
+  test "raw tls_options get passed through" do
+    tls_options = make_ref()
+    bamboo_config = configuration() |> Map.put(:tls_options, tls_options)
+
+    {:ok, "200 Ok 1234567890"} = SMTPAdapter.deliver(new_email(), bamboo_config)
+
+    assert [{_email, config}] = :sys.get_state(Process.whereis(FakeGenSMTP))
+
+    assert config[:tls_options] == tls_options
+  end
+
   test "check rfc822 encoding for subject" do
     bamboo_email =
       @email_in_utf8
@@ -794,6 +805,7 @@ defmodule Bamboo.SMTPAdapterTest do
     bamboo_email =
       @email_in_utf8
       |> new_email()
+
     bamboo_config = configuration()
     {:ok, "200 Ok 1234567890"} = SMTPAdapter.deliver(bamboo_email, bamboo_config)
     [{{from, to, _raw_email}, _gen_smtp_config}] = FakeGenSMTP.fetch_sent_emails()
@@ -803,7 +815,6 @@ defmodule Bamboo.SMTPAdapterTest do
     assert Enum.member?(to, "joe@xn--mjor-goa.com")
     assert Enum.member?(to, "mary@major.com")
   end
-
 
   defp format_email(emails), do: format_email(emails, true)
 


### PR DESCRIPTION
Since OTP 26, TLS checking has changed a bit. For gen_smtp it is now necessary (https://github.com/gen-smtp/gen_smtp/issues/328#issuecomment-1638095057) to pass in the tls_options which are retrieved from the :tls_certificate_check erlang module:

 tls_options: :tls_certificate_check.options(relay)
This patch allows the :tls_options configuration key to be passed through as-is to gen_smtp.